### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ ___
 An [IDE](https://mp.weixin.qq.com/debug/wxadoc/introduction/index.html?t=201758) (integrated development environment)  is a set of programming tools for writing an application. It consists of a code editor, a compiler and a debugger, accessible through a single graphical user interface.
 
 Download the WeChat IDE here:
- [Mac](https://servicewechat.com/wxa-dev-logic/download_redirect?type=darwin&from=mpwiki), [Windows 64](https://servicewechat.com/wxa-dev-logic/download_redirect?type=darwin&from=mpwiki), [Windows 32](https://servicewechat.com/wxa-dev-logic/download_redirect?type=ia32&from=mpwiki)
+ [Mac](https://servicewechat.com/wxa-dev-logic/download_redirect?type=darwin&from=mpwiki), [Windows 64](https://servicewechat.com/wxa-dev-logic/download_redirect?type=x64&from=mpwiki), [Windows 32](https://servicewechat.com/wxa-dev-logic/download_redirect?type=ia32&from=mpwiki)
 
 #### Quick tutorial
 


### PR DESCRIPTION
The link to the Windows 64 dev tools was the same as the Mac one.
I guessed at what the platform code was (x64) and changed the link. It seems to download a Windows 64 build.